### PR TITLE
Fix typo in practice test question

### DIFF
--- a/_sources/Tests/test4nt.rst
+++ b/_sources/Tests/test4nt.rst
@@ -78,7 +78,7 @@ The following problems are similar to what you might see on the AP CS A exam.  P
    :feedback_a: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) does NOT equal !A && B.
    :feedback_b: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) does NOT equal A && !B. !(x >= 7) is the same as (x < 7).
    :feedback_c: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) does NOT equal !A && !B. Also, the negation of (x > 2) is (x <= 2), not (x < 2).
-   :feedback_d: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) is equal to !A && !B, according to DeMorgan's law. The negation of !(x >= 7) is (x >= 7), and the negation of (x > 2) is (x <= 2).
+   :feedback_d: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) is equal to !A || !B, according to DeMorgan's law. The negation of !(x >= 7) is (x >= 7), and the negation of (x > 2) is (x <= 2).
    :feedback_e: Use A and B to represent the expressions -- A becomes !(x >= 7), B becomes (x > 2). ! (A && B) does NOT equal A || !B. The negation of (x > 2) is (x <= 2), not (x < 2), and !(x >= 7) is the same as (x < 7).
 
    Which of the following is equivalent to ``! (!(x >= 7) && (x > 2))``?

--- a/_sources/Tests/test4nt.rst
+++ b/_sources/Tests/test4nt.rst
@@ -537,7 +537,7 @@ The following problems are similar to what you might see on the AP CS A exam.  P
    :answer_e: 2000
    :correct: b
    :feedback_a: 2 ^ 9 is 512, which is not enough elements to cover every element in the database. Remember that binary search requires log2 (number of elements) iterations to perform.
-   :feedback_b: 2 ^ 11 is 2024. 11 iterations is more than enough to find the value or guarantee that it is not in the database. Binary search takes log2 (number of elements) iterations to perform.
+   :feedback_b: 2 ^ 11 is 2048. 11 iterations is more than enough to find the value or guarantee that it is not in the database. Binary search takes log2 (number of elements) iterations to perform.
    :feedback_c: The value will be found in 20 iterations, but a smaller number of iterations could be used.
    :feedback_d: The value will be found in 20 iterations, but a smaller number of iterations could be used. Remember that binary search requires log2 (number of elements) iterations to perform correctly.
    :feedback_e: This would be true if we used a sequential search algorithm. However, binary search only needs log2 (number of elements) iterations.


### PR DESCRIPTION
DeMorgan's Law was incorrectly used to say !(x && y) is equivalent to !x && !y, should say !x || !y