### PR TITLE
Remove sphinx_settings.json from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,13 +15,5 @@ _sources copy/Appendix/DrJava.rst
 
 # Machine specific files
 .DS_Store
-_sources/.DS_Store
-_sources/.DS_Store
-_sources/.DS_Store
-_sources/.DS_Store
 pavement.py
 sphinx_settings.json
-pavement.py
-sphinx_settings.json
-pavement.py
-pavement.py

--- a/sphinx_settings.json
+++ b/sphinx_settings.json
@@ -1,1 +1,0 @@
-{"SPHINX_SOURCE_PATH": "_sources", "SPHINX_OUT_PATH": "build\\csawesome"}


### PR DESCRIPTION
I'm pretty sure this just got checked into git at some point by accident. It was already in `.gitignore` but once it's checked in  it can't be ignored. And it changes all the time when you run a build, at least with the new tools and it doesn't seem like it matters if it's there. (As far as I can tell it is is a write-only file.)

This PR also cleans up `.gitignore` a bit since I went in there thinking I needed to add `sphinx_settings.json`.