### PR TITLE
Replacing most uses of 'command' with something more precise.

### DIFF
--- a/_sources/Unit1-Getting-Started/topic-1-2-java-intro.rst
+++ b/_sources/Unit1-Getting-Started/topic-1-2-java-intro.rst
@@ -120,14 +120,14 @@ You can copy the Java source code shown in this book into a file and save it if 
 
 
 
-Print Commands
+Print Methods
 -------------------
 
 .. index::
    single: String
    single: String literal
 
-Java has two different print commands to print output to the screen:
+Java has two different methods to print output to the screen:
 
 - **System.out.println(value)** : prints the value followed by a new line (ln)
 - **System.out.print(value)** : prints the value without advancing to the next line
@@ -135,7 +135,7 @@ Java has two different print commands to print output to the screen:
 
 ``System.out.println("Hi there!");`` prints out the characters between the first ``"`` and the second ``"`` followed by a new line.  The ``"Hi there!"`` is called a **string literal**, and it can have zero to many characters enclosed in starting and ending double quotes.
 
-.. activecode:: printCommands
+.. activecode:: printMethods
    :language: java
    :autograde: unittest
 
@@ -184,7 +184,7 @@ Java has two different print commands to print output to the screen:
         }
    }
 
-Most command keywords in Java must be in lowercase, but class names such as System and String are capitalized. Commands in Java must end with a semicolon (;). Think of the semicolon (;) in Java like a period (.) in English. You use a semicolon (``;``) to show the end of a Java **statement**, just the way you use a period (.) to show the end of an English sentence.  You will not be penalized on the exam if you forget the semicolon.  However, your programs won't run without it.
+Most special words in Java like ``public``, ``class``, and ``if``  must be in lowercase, but class names such as ``System`` and ``String`` are capitalized. Lines in a Java program that express a complete action such as assigning a value to a variable must end with a semicolon (``;``). Such a line is called a **statement**. You can think of the semicolon (``;``) in Java like a period (``.``) in English. The same way you use a period to end a sentence in English, you use a semicolon to end a statement in Java.  You will not be penalized on the exam if you forget a needed semicolon but the Java compiler is not so lenient; your program won't compile without it. Note also that not *every* line ends with a semicolon; if the line starts a construct like an `if` statement, there is no semicolon before the opening ``{`` nor one after the closing ``}``.
 
 Syntax Errors and Debugging
 -----------------------------
@@ -354,7 +354,7 @@ Click on the |runbutton| button below to try and run the following code.  Look f
 
 |CodingEx| **Coding Exercise: Compile Time Error 3**
 
-Click on the |runbutton| button below to try and run the following code.  What is wrong this time?  Can you fix it?  After you fix the first error, you may encounter a 2nd error! Fix that one too! Hints: How do you end a command in Java? Also, check for capitalization.
+Click on the |runbutton| button below to try and run the following code.  What is wrong this time?  Can you fix it?  After you fix the first error, you may encounter a 2nd error! Fix that one too! Hints: How do you end a statement in Java? Also, check for capitalization.
 
 .. activecode:: sc2error3
    :language: java
@@ -485,9 +485,9 @@ Summary
 
 - A **string literal** is enclosed in double quotes ('' '').
 
-- Java command lines end in ; (semicolon). { } are used to enclose blocks of code. // and ``/* */`` are used for comments.
+- Java statements end in ``;`` (semicolon). ``{ }`` are used to enclose blocks of code. ``//`` and ``/* */`` are used for comments.
 
-- A **compiler** translates Java code into a class file that can be run on your computer. **Compiler or syntax errors** are reported to you by the compiler if the Java code is not correctly written. Some things to check for are ; at end of command lines, matching { }, (), and "".
+- A **compiler** translates Java code into a class file that can be run on your computer. **Compiler or syntax errors** are reported to you by the compiler if the Java code is not correctly written. Some things to check for are ``;`` at end of lines containing complete statements and matching ``{ }``, ``()``, and ``""``.
 
 AP Practice
 ------------
@@ -572,7 +572,7 @@ AP Practice
 
     - Putting the semicolon after the ) on each line.
 
-      + Correct! The semicolon should go after each command but not in the comment.
+      + Correct! The semicolon should go after each statement but not in the comment.
 
 
 .. hparsons:: mp-main-method-order-1

--- a/_sources/Unit1-Getting-Started/topic-1-2-java-intro.rst
+++ b/_sources/Unit1-Getting-Started/topic-1-2-java-intro.rst
@@ -135,7 +135,7 @@ Java has two different methods to print output to the screen:
 
 ``System.out.println("Hi there!");`` prints out the characters between the first ``"`` and the second ``"`` followed by a new line.  The ``"Hi there!"`` is called a **string literal**, and it can have zero to many characters enclosed in starting and ending double quotes.
 
-.. activecode:: printMethods
+.. activecode:: printCommands
    :language: java
    :autograde: unittest
 
@@ -184,7 +184,7 @@ Java has two different methods to print output to the screen:
         }
    }
 
-Most special words in Java like ``public``, ``class``, and ``if``  must be in lowercase, but class names such as ``System`` and ``String`` are capitalized. Lines in a Java program that express a complete action such as assigning a value to a variable must end with a semicolon (``;``). Such a line is called a **statement**. You can think of the semicolon (``;``) in Java like a period (``.``) in English. The same way you use a period to end a sentence in English, you use a semicolon to end a statement in Java.  You will not be penalized on the exam if you forget a needed semicolon but the Java compiler is not so lenient; your program won't compile without it. Note also that not *every* line ends with a semicolon; if the line starts a construct like an `if` statement, there is no semicolon before the opening ``{`` nor one after the closing ``}``.
+Special words—also called **keywords**—such as ``public``, ``class``, and ``if`` must be in lowercase, but class names such as ``System`` and ``String`` are capitalized. Lines in a Java program that express a complete action such as assigning a value to a variable must end with a semicolon (``;``). Such a line is called a **statement**. You can think of the semicolon (``;``) in Java like a period (``.``) in English. The same way you use a period to end a sentence in English, you use a semicolon to end a statement in Java.  You will not be penalized on the exam if you forget a needed semicolon but the Java compiler is not so lenient; your program won't compile without it. Note also that not *every* line ends with a semicolon; if the line starts a construct like an `if` statement, there is no semicolon before the opening ``{`` nor one after the closing ``}``.
 
 Syntax Errors and Debugging
 -----------------------------

--- a/_sources/Unit4-Iteration/topic-4-2-for-loops.rst
+++ b/_sources/Unit4-Iteration/topic-4-2-for-loops.rst
@@ -429,7 +429,7 @@ Turtle Loops
 
 |CodingEx| **Coding Exercise**
 
-Do you remember when we used the turtle objects to draw shapes? To create a square without loops we had to repeat code to go forward and turn 90 degrees to the right 4 times like below. Can you change the code below to remove the repeated lines of code and use a loop to draw 4 sides of the square? Did you notice that the code becomes a lot shorter? You should only need 1 forward and 1 turn command in the loop. Whenever you find yourself repeating code, try to use a loop instead!
+Do you remember when we used the turtle objects to draw shapes? To create a square without loops we had to repeat code to go forward and turn 90 degrees to the right 4 times like below. Can you change the code below to remove the repeated lines of code and use a loop to draw 4 sides of the square? Did you notice that the code becomes a lot shorter? You should only need 1 call to forward and 1 call to turn in the loop. Whenever you find yourself repeating code, try to use a loop instead!
 
 (If the code below does not work for you, you can copy the code into  this |repl link| (refresh page after forking and if it gets stuck) or download the files |github| to use in your own IDE.)
 

--- a/_sources/Unit6-Arrays/topic-6-1-array-basics.rst
+++ b/_sources/Unit6-Arrays/topic-6-1-array-basics.rst
@@ -144,7 +144,7 @@ To create an empty array after declaring the variable, use the **new** keyword w
    :autograde: unittest
    :practice: T
 
-   In the following code, add another two mroe array declaration, one that creates an array of 5 doubles called prices and another of 5 Strings called names. Then add ``System.out.println`` calls to print their lengths.
+   In the following code, add another two more array declarations, one that creates an array of 5 doubles called prices and another of 5 Strings called names. Then add ``System.out.println`` calls to print their lengths.
    ~~~~
    public class Test1
    {

--- a/_sources/Unit6-Arrays/topic-6-1-array-basics.rst
+++ b/_sources/Unit6-Arrays/topic-6-1-array-basics.rst
@@ -144,7 +144,7 @@ To create an empty array after declaring the variable, use the **new** keyword w
    :autograde: unittest
    :practice: T
 
-   In the following code, add another array declaration that creates an array of 5 doubles called prices and another array of 5 Strings called names and corresponding System.out.println commands.
+   In the following code, add another two mroe array declaration, one that creates an array of 5 doubles called prices and another of 5 Strings called names. Then add ``System.out.println`` calls to print their lengths.
    ~~~~
    public class Test1
    {

--- a/_sources/Unit7-ArrayList/2013gridworldQ3A.rst
+++ b/_sources/Unit7-ArrayList/2013gridworldQ3A.rst
@@ -108,7 +108,7 @@ You can skip these if you think you know what to do already.  Click the buttons 
       :answer_d: .getNumRows()
       :correct: d
       :feedback_a: This call works for strings, but we aren't working with strings.
-      :feedback_b: This is not an applicable command for grid
+      :feedback_b: This is not an applicable method for grid
       :feedback_c: This does not exist.
       :feedback_d: Correct, this will return the height of the grid.
 

--- a/_sources/Unit7-ArrayList/stringScrambleB.rst
+++ b/_sources/Unit7-ArrayList/stringScrambleB.rst
@@ -109,7 +109,7 @@ This section contains a plain English explanation of one way to solve this probl
        :answer_c: (index < wordList.size())
        :answer_d: (wordList(index) != wordList.size())
        :correct: c
-       :feedback_a: the .current() command does not exist
+       :feedback_a: the .current() method does not exist
        :feedback_b: this form of range control does not work with while loops
        :feedback_c: Correct!
        :feedback_d: this does not accurately update the list as you iterate through wordList

--- a/_sources/Unit7-ArrayList/topic-7-2-arraylist-methods.rst
+++ b/_sources/Unit7-ArrayList/topic-7-2-arraylist-methods.rst
@@ -612,7 +612,7 @@ Note that the ArrayList methods add and remove do not have a simple equivalent i
               + toDoList[0] );
 
           // remove item 0 and move everything down
-          //  (this can be done in 1 command with ArrayList)
+          //  (this can be done in one method call with ArrayList)
           toDoList[0] = toDoList[1];
           toDoList[1] = toDoList[2];
           toDoList[2] = "";


### PR DESCRIPTION
This is another one of my opinions about vocabulary but I like to try to use the standard terminology for things like methods, calls, and statements. And I definitely prefer to use distinct terms rather than lumping them under a catchall like "command". "Command" also has a very strong imperative flavor; makes me think we're programming in BASIC or something. As always, my $0.02, ymmv, etc.

One thing I wasn't sure about was does it matter if we change the name after an `activecode::` directive? I changed `printCommands` to `printMethods` at line 138 of `_sources/Unit1-Getting-Started/topic-1-2-java-intro.rst` to be consistent but it occurs to me that that might mess up some data collection for our researchers if that makes it look like one problem went a way and a new one appeared.

