### PR TITLE
Give the section headers a bit of breathing room.

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -26,3 +26,17 @@ a,
 {
   text-decoration: underline !important;
 }
+
+section h1,
+.runestone-sphinx section h1
+{
+  padding-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+section section h2,
+.runestone-sphinx section section h2
+{
+  padding-top: 0.5em;
+  margin-bottom: 0.5em;
+}


### PR DESCRIPTION
To my eye this makes the pages a bit more pleasing. 

Before:

![2023-06-21 at 5 52 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/b0031837-ed0e-4cd2-9100-8769a558eafe)

After:

![2023-06-21 at 5 53 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/895ea10e-e821-4c4b-9a46-d982cce1ccf1)

Though those images don't do a good job of showing the extra space at the top of the page.