### PR TITLE
Swap the color of the text and border color in header elements.

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -9,8 +9,8 @@ h2,
 .runestone-sphinx h1,
 .runestone-sphinx h2
 {
-    color:  #70d549;
-    border-bottom: 5px groove #00b3e3;
+    color:  #00b3e3;
+    border-bottom: 2px solid  #70d549;
 }
 
 strong,

--- a/conf.py
+++ b/conf.py
@@ -186,7 +186,7 @@ html_short_title ='AP CSAwesome'
 # of the sidebar.
 
 # logo is included in layout file
-#html_logo = "../source/_static/logo_small.png"
+html_logo = "_static/CSAwesomeLogo.png"
 
 
 # The name of an image file (within the static path) to use as favicon of the


### PR DESCRIPTION
Looks like this now:

![2023-06-21 at 7 49 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/cd164fd7-7f15-46ed-926d-e591c66df73e)

I went back and forth on whether the border should be `2px` or `3px`. 