### PR TITLE
Proof of concept of converting time estimates to styled text.

### DIFF
--- a/_sources/Unit2-Using-Objects/topic-2-1-objects-intro-turtles.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-1-objects-intro-turtles.rst
@@ -33,13 +33,15 @@
 
    <a href="https://github.com/bhoffman0/APCSA-2019/tree/master/_sources/Unit2-Using-Objects/TurtleJavaSwingCode.zip" target="_blank" style="text-decoration:underline">here</a>
 
-.. |clock| unicode:: x1F567
+.. raw:: html
 
+   <div class="unit-time">
+     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clock" viewBox="0 0 16 16">
+       <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/>
+       <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z"/>
+     </svg> Time estimate: 45 min.
+   </div>
 
-
-.. image:: ../../_static/time45.png
-    :width: 250
-    :align: right
 
 Objects - Instances of Classes
 ===============================

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -17,7 +17,7 @@ strong,
 .runestone-sphinx strong
 {
     color:  #0550FF; /*#1E90FF;  #00b3e3*/
-    background-color: ghostwhite;
+/*    background-color: ghostwhite;*/
     font-weight: bolder;
 }
 
@@ -64,4 +64,21 @@ section section h2,
 
 #aboutcsa-table thead {
   background-color: lightblue;
+}
+
+
+.runestone-sphinx div.unit-time
+{
+  clear: right;
+  float: right;
+  width: 50%;
+  text-align: right;
+  font-size: 16px;
+  padding: 1em;
+  color: grey;
+}
+
+.runestone-sphinx div.unit-time svg {
+  display: inline;
+  vertical-align: middle;
 }


### PR DESCRIPTION
This is just a POC as I only did it on one page. But it fixes the dark-mode issue with the time estimate images and also probably makes the page a tiny bit more accessible to someone using a screen reader or whatever.

Light mode:

![2023-06-21 at 8 47 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/aed29515-97b9-4159-bc5d-ae926f3b9c87)

Dark mode:

![2023-06-21 at 8 48 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/a87f7732-ea85-4fa8-b184-2ed30a9a1506)

I'm not sure but I think the `<svg>` may need to be inline to inherit the color.