### PR TITLE
Change color of header elements to be more accessible.

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -9,6 +9,15 @@ h2,
 .runestone-sphinx h1,
 .runestone-sphinx h2
 {
+    color:  #007d9f;
+    border-bottom: 2px solid  #70d549;
+}
+
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] .runestone-sphinx h1,
+[data-theme="dark"] .runestone-sphinx h2
+{
     color:  #00b3e3;
     border-bottom: 2px solid  #70d549;
 }

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -4,29 +4,28 @@
  * remove the selectors without the `.runestone-sphinx` class.
  */
 
+:root {
+    --emphasisColor: #007d9f;
+}
+
+:root[data-theme="dark"] {
+    --emphasisColor: #00b3e3;
+}
+
+
 h1,
 h2,
 .runestone-sphinx h1,
 .runestone-sphinx h2
 {
-    color:  #007d9f;
-    border-bottom: 2px solid  #70d549;
-}
-
-[data-theme="dark"] h1,
-[data-theme="dark"] h2,
-[data-theme="dark"] .runestone-sphinx h1,
-[data-theme="dark"] .runestone-sphinx h2
-{
-    color:  #00b3e3;
+    color:  var(--emphasisColor);
     border-bottom: 2px solid  #70d549;
 }
 
 strong,
 .runestone-sphinx strong
 {
-    color:  #0550FF; /*#1E90FF;  #00b3e3*/
-    background-color: ghostwhite;
+    color:  var(--emphasisColor);
     font-weight: bolder;
 }
 
@@ -75,6 +74,9 @@ section section h2,
   background-color: lightblue;
 }
 
+/*
+ * Time estimates at the top right of some pages.
+ */
 
 .runestone-sphinx div.unit-time
 {


### PR DESCRIPTION
This is just a small patch in case we care about the contrast issues raised in the comments on the other PR. This darkens the header text (by multiplying each RGB component by 0.7) in normal mode and keeps it the same for dark mode, giving both cases reasonable scores for uses other than "small text" (which these should not be) according to:

https://accessibleweb.com/color-contrast-checker/

Here's the new light mode:

![2023-06-22 at 12 27 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/dc6a06e7-40ea-4955-898e-0e1e73553655)

And dark mode is the same as before:

![2023-06-22 at 12 29 PM](https://github.com/bhoffman0/CSAwesome/assets/250053/5ed82524-5189-4c00-95b9-0301f90f5509)
