### PR TITLE
Reworking 9.7.3

### DIFF
--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -384,7 +384,7 @@ and in Spanish which is what we call a “foot” in English.
 
            if (!(other instanceof Word))
            {
-               // It can’t be the same Word if it’s not a Word at all.
+               // It can't be the same Word if it's not a Word at all.
                // This also ensures that o.equals(null) is false because
                // null is not an instanceof any class.
                return false;

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -393,8 +393,8 @@ and in Spanish which is what we call a “foot” in English.
            // Now we now we can safely cast other to a Word and
            // check if our two attributes are the same, using
            // equals to compare them because they are Strings.
-           Word otheWord = (Word) other;
-           return name.equals(otherWord.name) && language.equals(otherWord.language);
+           Word otherWord = (Word) other;
+           return spelling.equals(otherWord.spelling) && language.equals(otherWord.language);
        }
 
        public static void main(String[] args)

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -606,5 +606,8 @@ Summary
   - ``String toString()``
   - ``boolean equals(Object other)``
 
+- Subclasses of Object often override the ``toString`` and ``equals`` methods
+  with class-specific implementations.
 
-- Subclasses of Object often override the equals and toString methods with class-specific implementations.
+- When overriding ``equals``, it’s important to satisfy all the requirements of
+  a correct implementation.

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -471,7 +471,7 @@ method in one class in a class hierarchy.
 |Groupwork| Programming Challenge : Savings Account
 ---------------------------------------------------
 
-In the following code, contains the beginning of a class for representing a bank
+The following code contains the beginning of a class for representing a bank
 account containing the account holder's name and the money balance in the
 account.
 

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -43,7 +43,7 @@ Object Superclass
 ====================
 
 The ``Object`` class is the superclass of all other classes in Java and a part
-of the built-in ``java.lang`` package. If a parent class isn't specified using
+of the built-in ``java.lang`` package. If a parent class isn’t specified using
 the ``extends`` keyword, the class will inherit from the ``Object`` class. What
 does a class inherit from the ``Object`` class? The |AP CSA Reference Sheet|
 lists the two main methods that are most frequently used:
@@ -175,13 +175,11 @@ object called ``obj`` are equal. But what does that mean?
     single: override
     single: equals
 
-As seen in the code below, the ``equals`` method that is inherited from the
-``Object`` class only returns ``true`` if the two objects references refer to
-the same object.
+As you can see if you run the code below, the ``equals`` method inherited from
+``Object`` only returns ``true`` if the two objects references refer to the same
+object. In other words it is does the same test as ``==``.
 
 |CodingEx| **Coding Exercise**
-
-
 
 .. activecode:: ObjEquals
    :language: java
@@ -191,51 +189,47 @@ the same object.
    ~~~~
    public class Person
    {
-      private String name;
+       private String name;
 
-      public Person(String theName)
-      {
-         this.name = theName;
-      }
+       public Person(String theName)
+       {
+           this.name = theName;
+       }
 
-      public static void main(String[] args)
-      {
-         Person p1 = new Person("Kairen");
-         Person p2 = new Person("Jewel");
-         Person p3 = new Person("Kairen");
-         Person p4 = p3;
-         System.out.println(p1.equals(p2));
-         System.out.println(p2.equals(p3));
-         System.out.println(p1.equals(p3));
-         System.out.println(p3.equals(p4));
-
-      }
+       public static void main(String[] args)
+       {
+           Person p1 = new Person("Kairen");
+           Person p2 = new Person("Jewel");
+           Person p3 = new Person("Kairen");
+           Person p4 = p3;
+           System.out.println(p1.equals(p2));
+           System.out.println(p2.equals(p3));
+           System.out.println(p1.equals(p3));
+           System.out.println(p3.equals(p4));
+       }
    }
    ====
    import static org.junit.Assert.*;
-     import org.junit.*;
-     import java.io.*;
+   import org.junit.*;
+   import java.io.*;
 
-     public class RunestoneTests extends CodeTestHelper
-     {
-         public RunestoneTests() {
-             super("Person");
-         }
+   public class RunestoneTests extends CodeTestHelper
+   {
+       public RunestoneTests() {
+           super("Person");
+       }
 
-         @Test
-         public void test1()
-         {
-             String output = getMethodOutput("main");
-             String expect = "false\nfalse\nfalse\ntrue";
+       @Test
+       public void test1()
+       {
+           String output = getMethodOutput("main");
+           String expect = "false\nfalse\nfalse\ntrue";
 
-             boolean passed = getResults(expect, output, "Checking output from main()", true);
-             assertTrue(passed);
+           boolean passed = getResults(expect, output, "Checking output from main()", true);
+           assertTrue(passed);
 
-         }
-     }
-
-
-The ``equals`` method inherited from the ``Object`` class only returns true when the two references point to the same object as shown in the code above and figure 1 below.
+       }
+   }
 
 .. figure:: Figures/equalsEx.png
     :width: 300px
@@ -247,11 +241,22 @@ The ``equals`` method inherited from the ``Object`` class only returns true when
 Overriding the ``equals`` Method
 --------------------------------
 
-If you want to change how the inherited ``equals`` method works you can
-**override** it so that the new method is called instead of the inherited one.
-The ``String`` class **overrides** the inherited equals method to return
-``true`` when the two objects have the same characters in the same order as
-shown in the code below.
+The ``equals`` method defined in ``Object`` and thus inherited by all classes
+only considers two object references equivalent if they refer to exactly the
+same object. But we saw in Unit 2 that the ``String`` class provides an
+``equals`` method that considers two ``String`` objects equivalent if they have
+the same characters in the same order, even if they are actually different
+objects. How does that work?
+
+It is because the ``String`` class has **overridden** the ``equals`` method it
+inherited from ``Object`` to provide a definition of equality that makes more
+sense.
+
+As we saw in section 9.3 a class can override inherited methods by providing a
+method with the same method signature (method name, parameter types, and return
+type). ``String`` has done that with ``equals`` so when we compare ``String``
+objects with ``equals`` that new method will be called instead of the inherited
+one.
 
 |CodingEx| **Coding Exercise**
 
@@ -297,7 +302,46 @@ shown in the code below.
          }
      }
 
-Any class can override the inherited ``equals`` method by providing a method with the same method signature (method name and parameter list) and return type.  The provided method will be called instead of the inherited one, which is why we say that the new method **overrides** the inherited method.  The ``Person`` class below **overrides** the inherited ``equals`` method.
+However, overriding ``equals`` is a bit more involved than overriding
+``toString``. While the ``toString`` method is only required to produce a
+reasonable human-readable ``String`` representation of an object, ``equals`` has
+to meet a more complex set of requirements in order to be useful.
+
+You will not be expected to write your own ``equals`` method on the AP exam but
+it’s worth looking at what those requirements are and how to satisify them.
+There are five requirements described in the Javadocs for ``equals`` in
+``Object`` that a properly implemented ``equals`` must satisfy:
+
+#. Equality is **reflexive**, meaning an object will be ``equals`` to itself:
+   ``o.equals(o)`` is ``true``.
+
+#. Equality is **symmetric**: ``o1.equals(o2)`` returns the same value as
+   ``o2.equals(o1)``.
+
+#. Equality is **transitive**: if ``o1.equals(o2)`` and ``o2.equals(o3)`` then
+   ``o1.equals(o3)``.
+
+#. Equality is **consistent**: ``o1.equals(o2)`` always returns the same value
+   assuming the objects are not modified.
+
+#. No object is equal to ``null``: ``o.equals(null)`` is always ``false``.
+
+The other way to look at these requirements is as guarantees that are made to
+you as a user of ``equals``. If you look at it that way, these requirements are
+quite nice. Imagine how much harder it would be to use the ``String`` equals
+method if you couldn't rely on the fact that ``s1.equals(s2)`` is necessarily
+the same as ``s2.equals(s1)``!
+
+So even though the Java compiler can't force you to implement ``equals``
+correctly, if you ever do want to override it, it’s important that you do. Let’s
+look at what’s involved.
+
+We'll write a class ``Word`` which represents a word in a particular language.
+We want two ``Word`` objects to be considered ``equals`` if and only if they are
+spelled the same `and` come from the same languag. The latter requirement is
+because sometimes different languages have words that are spelled the same but
+with different meanings such as “pie” which in English is a tasty baked treat
+and in Spanish which is what we call a “foot” in English.
 
 |CodingEx| **Coding Exercise**
 
@@ -306,44 +350,64 @@ Any class can override the inherited ``equals`` method by providing a method wit
    :language: java
    :autograde: unittest
 
-   Try to guess what this code will print out before running it. Click on the CodeLens button to step forward through the code and watch the memory.
-   ~~~~
-   public class Person
-   {
-       private String name;
+   Try to guess what this code will print out before running it. Click on the
+   CodeLens button to step forward through the code and watch the memory.
 
-       public Person(String theName)
+   ~~~~
+   public class Word
+   {
+       private String spelling;
+       private String language;
+
+       public Word(String spell, String lang)
        {
-           this.name = theName;
+           this.spelling = spell;
+           this.language = lang;
        }
 
-       /** overridden equals method that checks if names are equal
-          in this Person object and an the other Object.
-          */
+       /**
+        * Compares this word to the specified object. The result is true if and
+        * only if the argument is not null and is a Word object with the same
+        * spelling and language as this object.
+        */
        public boolean equals(Object other)
        {
-           if (!(other instanceof Person))
+           if (this == other)
            {
-               // Can't be equal if it's not another Person
+               // This is not strictly necessary assuming the rest
+               // of the method is implemented correctly but it is
+               // a commonly used optimization because the == check
+               // is very fast. Thus this is a quick way to guarantee
+               // that our equals method is reflexive.
+               return true;
+           }
+
+           if (!(other instanceof Word))
+           {
+               // It can’t be the same Word if it’s not a Word at all.
+               // This also ensures that o.equals(null) is false because
+               // null is not an instanceof any class.
                return false;
            }
-           // Now we now we can safely cast other to a Person ...
-           Person otherPerson = (Person) other;
-           // ... and check if the names are equal
-           return this.name.equals(otherPerson.name);
+
+           // Now we now we can safely cast other to a Word and
+           // check if our two attributes are the same, using
+           // equals to compare them because they are Strings.
+           Word otheWord = (Word) other;
+           return name.equals(otherWord.name) && language.equals(otherWord.language);
        }
 
        public static void main(String[] args)
        {
-           Person p1 = new Person("Gabe");
-           Person p2 = new Person("Gus");
-           Person p3 = new Person("Gabe");
-           Person p4 = p3;
+           Word p1 = new Word("pie", "english");
+           Word p2 = new Word("pie", "spanish");
+           Word p3 = new Word("pie", "english");
+           Word p4 = p3;
            System.out.println(p1.equals(p2));
            System.out.println(p2.equals(p3));
            System.out.println(p1.equals(p3));
            System.out.println(p3.equals(p4));
-           System.out.println(p1.equals("Gabe"));
+           System.out.println(p1.equals("pie"));
        }
    }
    ====
@@ -354,7 +418,7 @@ Any class can override the inherited ``equals`` method by providing a method wit
      public class RunestoneTests extends CodeTestHelper
      {
          public RunestoneTests() {
-             super("Person");
+             super("Word");
          }
 
          @Test
@@ -369,78 +433,64 @@ Any class can override the inherited ``equals`` method by providing a method wit
          }
      }
 
-.. figure:: Figures/overrideEquals.png
-    :width: 300px
-    :align: center
-    :figclass: align-center
+The basic recipe for writing your own equals method, is:
 
-    Figure 2: A picture from the Java Visualizer showing the object references and objects.
+#. Use the ``public boolean equals(Object other)`` method signature. Make sure
+   the parameter type is ``Object``, not the class you are defining.
 
-You can step through this code in the Java Visualizer by clicking on the following link: `OverrideEquals Ex <http://cscircles.cemc.uwaterloo.ca/java_visualize/#code=public+class+Person%0A%7B%0A++++++private+String+name%3B%0A++++++%0A++++++public+Person(String+theName)%0A++++++%7B%0A+++++++++this.name+%3D+theName%3B%0A++++++%7D%0A++++++%0A++++++public+boolean+equals(Object+other)%0A++++++%7B%0A+++++++++Person+otherPerson+%3D+(Person)+other%3B%0A+++++++++return+this.name.equals(otherPerson.name)%3B%0A++++++%7D%0A++++++%0A++++++public+static+void+main(String%5B%5D+args)%0A++++++%7B%0A+++++++++Person+p1+%3D+new+Person(%22Gabe%22)%3B%0A+++++++++Person+p2+%3D+new+Person(%22Gus%22)%3B%0A+++++++++Person+p3+%3D+new+Person(%22Gabe%22)%3B%0A+++++++++Person+p4+%3D+p3%3B%0A+++++++++System.out.println(p1.equals(p2))%3B%0A+++++++++System.out.println(p2.equals(p3))%3B%0A+++++++++System.out.println(p1.equals(p3))%3B%0A+++++++++System.out.println(p3.equals(p4))%3B%0A+++++++++%0A++++++%7D%0A%7D&mode=display&curInstr=23>`_.
+#. Check of ``this == other`` to quickly return ``true`` when comparing an
+   object to itself.
 
-To write your own equals method, you must:
+#. Use ``instanceof`` to check if `other` is an instance of this class and
+   return ``false`` if not.
 
-1. Use the ``public boolean equals(Object other)`` method signature
+#. Cast ``other`` to the current class.
 
-2. Use ``instanceof`` to check if `other` is an instance of this class and return ``false`` if not.
+#. Finally compare this object’s attributes to the other object's with ``==``
+   for primitive types like ``int`` and ``double`` and ``equals`` for reference
+   types. If you need to compare multiple attributes ``&&`` together the
+   comparisons of the individual attributes since two objects should only be
+   equal if `all` the attributes match.
 
-3. Type cast ``other`` to the current class
+Note that the requirements on ``equals`` make it almost impossible to correctly
+override it in a subclass of a class that has already overridden the ``Object``
+version. To see why, imagine if we made a subclass of ``Word``,
+``ClassifiedWord`` and added another attribute, ``partOfSpeech``.
 
-4. Return whether this object's attribute(s) equals the other object's attribute(s) with ``==`` for primitive types like ``int`` and ``double``, or ``equals`` for reference types like ``String`` or another class.
-
-.. code-block:: java
-
-    public boolean equals(Object other)
-    {
-       if (!(other instanceof Classname))
-       {
-           return false;
-       }
-       // Type cast other to your Classname
-       Classname otherObj = (Classname) other;
-       // Check if attributes are equal
-       return (this.attribute == otherObj.attribute);
-       // or this.attribute.equals(otherObj.attribute) if attribute is a reference type
-    }
-
-If you need to check multiple attributes, for example a name and an address for Person objects, you can use && to combine tests.
-
-.. code-block:: java
-
-    return (this.attribute1 == otherObj.attribute1) &&
-           this.attribute2.equals(otherObj.attribute2)
-
-..
-  This is actually not really good advice. Overriding equals is unfortunately
-  quite complex in that there are a bunch of requirements on the contract. On of
-  which is that it be symmetric, i.e. o1.equals(o2) == o2.equals(o1). But if a
-  subclass overrides equals as described here it breaks symetry because
-  super.equals(sub) could return true while sub.equals(super) might return
-  false. Obviously we don't want to get into that whole mess but maybe it's
-  worth not leading them astray here.
-
-If you are writing an equals method for a subclass, you can call the superclass equals using the **super** keyword to check the attributes in the superclass and then check the attributes in the subclass.
-
-.. code-block:: java
-
-    return super.equals(otherObj) &&
-           (this.attribute == otherObj.attribute)
+If we override ``equals`` in the ``ClassifiedWord`` to only consider two
+``ClassifiedWord`` objects ``equals`` if their spelling, language, `and` part of
+speech match, that will break the symmetry since
+``regularWord.equals(classifiedWord)`` will invoke the ``equals`` from ``Word``
+which will only compare the spelling and language of the word but
+``classifiedWord.equals(regularWord)`` will return ``false`` assuming the
+``equals`` in ``ClassifiedWord`` checks that ``other`` is an ``instanceof
+ClassifiedWord``. In general you should only provide an overridden ``equals``
+method in one class in a class hierarchy.
 
 
 |Groupwork| Programming Challenge : Savings Account
 ---------------------------------------------------
 
-In the following code, a bank account class contains the account holder's name and the money balance in the account.
+In the following code, contains the beginning of a class for representing a bank
+account containing the account holder's name and the money balance in the
+account.
 
-Work in pairs to write the following code and test each part before moving on to the next step:
+Work in pairs to write the following code and test each part before moving on to
+the next step:
 
-1. Write a subclass called ``SavingsAccount`` that extends ``Account`` and  adds an interest rate variable.
+#. Implement a ``toString`` method in ``Account`` that returns a ``String``
+   representing the instance variables in ``Account`` in the form name, comma,
+   space, balance.
 
-2. Write a constructor with 3 arguments (name, balance, interest rate) for the ``SavingsAccount`` class that uses the super constructor.
+#. Write a subclass called ``SavingsAccount`` that extends ``Account`` and adds
+   an interest rate variable.
 
-3. Write a ``toString`` method for ``SavingsAccount`` that returns a call to the super ``toString`` method and the interest rate.
+#. Write a constructor with 3 arguments (name, balance, interest rate) for the
+   ``SavingsAccount`` class that uses the super constructor.
 
-4. Write an ``equals`` method for ``SavingsAccount`` that calls the `super class ``equals`` method and checks that the interest rates are equal.
+#. Write a ``toString`` method for ``SavingsAccount`` that returns a string
+   consisting of the result of the superclass’s ``toString`` plus a comma, a
+   space, and the interest rate.
 
 
 .. activecode:: challenge-9-7-savingsaccount
@@ -464,16 +514,7 @@ Work in pairs to write the following code and test each part before moving on to
           this.balance = balance;
        }
 
-       public String toString() {
-        return name + ", " + balance;
-       }
-
-       public boolean equals(Object other)
-       {
-          Account otherAccount = (Account) other;
-          return (this.balance == otherAccount.balance) &&
-                       this.name.equals(otherAccount.name);
-       }
+       // Implement toString here
 
        public static void main(String[] args)
        {
@@ -482,16 +523,16 @@ Work in pairs to write the following code and test each part before moving on to
            // Uncomment this code to test SavingsAccount
            /*
            SavingsAccount acct2 = new SavingsAccount("Dakota Jones",1500,4.5);
-           SavingsAccount acct3 = new SavingsAccount("Dakota Jones",1500,4.5);
            System.out.println(acct2);
-           System.out.println(acct2.equals(acct3));
            */
        }
    }
-   /* Write the SavingsAccount class which inherits from Account
-      and has an interest rate and a constructor, toString, and
-      equals methods.
-   */
+
+   /*
+    * Write the SavingsAccount class which inherits from Account,
+    * adds an interest rate instance variable. Write a constructor and a
+    * toString method.
+    */
    class SavingsAccount
    {
 
@@ -511,7 +552,7 @@ Work in pairs to write the following code and test each part before moving on to
          public void test1()
          {
              String output = getMethodOutput("main");
-             String expect = "Armani Smith, 1500.0\nDakota Jones, 1500.0, 4.5\ntrue";
+             String expect = "Armani Smith, 1500.0\nDakota Jones, 1500.0, 4.5";
 
              boolean passed = getResults(expect, output, "Checking output from main()");
              assertTrue(passed);
@@ -547,41 +588,10 @@ Work in pairs to write the following code and test each part before moving on to
          }
          @Test
          public void containsExtends()
-             {
+         {
                 String target = "SavingsAccount extends Account";
                 boolean passed = checkCodeContains(target);
                 assertTrue(passed);
-             }
-
-         @Test
-         public void test31()
-         {
-             String target = "public boolean equals(Object";
-
-             String code = getCode();
-             int index = code.indexOf("class SavingsAccount");
-             code = code.substring(index);
-
-             boolean passed = code.contains(target);
-
-             getResults("true", ""+passed, "Checking that code contains equals method in SavingsAccount", passed);
-             assertTrue(passed);
-         }
-
-         @Test
-         public void test32()
-         {
-             String target = "super.equals(";
-
-             String code = getCode();
-             int index = code.indexOf("class SavingsAccount");
-             code = code.substring(index);
-
-             boolean passed = code.contains(target);
-
-             getResults("true", ""+passed, "Checking that code contains call to super.equals() in SavingsAccount", passed);
-             assertTrue(passed);
-
          }
      }
 

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -529,9 +529,9 @@ the next step:
    }
 
    /*
-    * Write the SavingsAccount class which inherits from Account,
-    * adds an interest rate instance variable. Write a constructor and a
-    * toString method.
+    * Write the SavingsAccount class which inherits from Account. Add an
+    * interest rate instance variable and write a constructor and a toString
+    * method.
     */
    class SavingsAccount
    {

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -42,27 +42,41 @@
 Object Superclass
 ====================
 
-The **Object** class is the superclass of all other classes in Java and a part of the built-in java.lang package. If a parent class isn't specified using the **extends** keyword, the class will inherit from the ``Object`` class.  What does a class inherit from the ``Object`` class?  The |AP CSA Reference Sheet| lists the two main methods that are most used, toString() and equals(Object), from the Object class at the bottom, which are covered in more detail below.
+The ``Object`` class is the superclass of all other classes in Java and a part
+of the built-in ``java.lang`` package. If a parent class isn't specified using
+the ``extends`` keyword, the class will inherit from the ``Object`` class. What
+does a class inherit from the ``Object`` class? The |AP CSA Reference Sheet|
+lists the two main methods that are most frequenly:
 
-- String toString()
-- boolean equals(Object other)
+- ``String toString()``
+- ``boolean equals(Object other)``
 
 
 
-toString() method
+``toString()`` method
 -----------------
 
-One commonly overridden Object method is toString(), which is often used to print out the attributes of an object. It is a good idea to write your own toString() method in every class. In a subclass, toString() can call the superclass toString() method using super.toString() and then add on its own attributes.
+One commonly overridden ``Object`` method is ``toString()``, which is often used
+to print out the attributes of an object. It is a good idea to write your own
+``toString()`` method in every class. In a subclass, ``toString()`` can call the
+superclass ``toString()`` method using ``super.toString()`` and then add on its
+own attributes.
 
 |CodingEx| **Coding Exercise**
 
-In the following code, the Person class overrides the Object toString() method and the Student class overrides the Person toString() method. They each add on their attributes.
+In the following code, the ``Person`` class overrides the ``Object toString()``
+method and the ``Student`` class overrides the ``Person toString()`` method.
+They each add on their attributes.
 
 .. activecode:: toStringDemo
   :language: java
   :autograde: unittest
 
-  After trying the code below, complete the subclass called APStudent that extends Student with a new attribute called APscore and override the toString() method to call the superclass method and then add on the APscore. Uncomment the APStudent object in the main method to test it.
+  After trying the code below, complete the subclass called ``APStudent`` that
+  extends ``Student`` with a new attribute called ``APscore`` and override the
+  ``toString()`` method to call the superclass method and then add on the
+  ``APscore``. Uncomment the ``APStudent`` object in the main method to test it.
+
   ~~~~
   public class Person
   {
@@ -150,16 +164,20 @@ In the following code, the Person class overrides the Object toString() method a
 
 
 
-equals Method
+``equals`` Method
 -----------------
 
-One of the important things that gets inherited from the Object superclass is the ``equals(Object obj)`` method.  This method is used to test if the current object and the passed object called ``obj`` are equal. But what does that mean?
+One of the important methods inherited from ``Object`` is the ``equals(Object
+obj)`` method. This method is used to test if the current object and the passed
+object called ``obj`` are equal. But what does that mean?
 
 .. index::
     single: override
     single: equals
 
-As seen in the code below, the ``equals`` method that is inherited from the ``Object`` class only returns true if the two objects references refer to the same object.
+As seen in the code below, the ``equals`` method that is inherited from the
+``Object`` class only returns ``true`` if the two objects references refer to
+the same object.
 
 |CodingEx| **Coding Exercise**
 
@@ -226,10 +244,14 @@ The ``equals`` method inherited from the ``Object`` class only returns true when
 
     Figure 1: A picture from the Java Visualizer showing that only p3 and p4 refer to the same object.
 
-Overriding the equals Method
------------------------------
+Overriding the ``equals`` Method
+--------------------------------
 
-If you want to change how the inherited ``equals`` method works you can **override** it so that the new method is called instead of the inherited one.  The ``String`` class **overrides** the inherited equals method to return true when the two objects have the same characters in the same order as shown in the code below.
+If you want to change how the inherited ``equals`` method works you can
+**override** it so that the new method is called instead of the inherited one.
+The ``String`` class **overrides** the inherited equals method to return
+``true`` when the two objects have the same characters in the same order as
+shown in the code below.
 
 |CodingEx| **Coding Exercise**
 
@@ -288,35 +310,41 @@ Any class can override the inherited ``equals`` method by providing a method wit
    ~~~~
    public class Person
    {
-      private String name;
+       private String name;
 
-      public Person(String theName)
-      {
-         this.name = theName;
-      }
+       public Person(String theName)
+       {
+           this.name = theName;
+       }
 
-      /** overridden equals method that checks if names are equal
+       /** overridden equals method that checks if names are equal
           in this Person object and an the other Object.
           */
-      public boolean equals(Object other)
-      {
-         // Type cast other to a Person
-         Person otherPerson = (Person) other;
-         // Check if names are equal
-         return this.name.equals(otherPerson.name);
-      }
+       public boolean equals(Object other)
+       {
+           if (!(other instanceof Person))
+           {
+               // Can't be equal if it's not another Person
+               return false;
+           }
+           // Now we now we can safely cast other to a Person ...
+           Person otherPerson = (Person) other;
+           // ... and check if the names are equal
+           return this.name.equals(otherPerson.name);
+       }
 
-      public static void main(String[] args)
-      {
-         Person p1 = new Person("Gabe");
-         Person p2 = new Person("Gus");
-         Person p3 = new Person("Gabe");
-         Person p4 = p3;
-         System.out.println(p1.equals(p2));
-         System.out.println(p2.equals(p3));
-         System.out.println(p1.equals(p3));
-         System.out.println(p3.equals(p4));
-      }
+       public static void main(String[] args)
+       {
+           Person p1 = new Person("Gabe");
+           Person p2 = new Person("Gus");
+           Person p3 = new Person("Gabe");
+           Person p4 = p3;
+           System.out.println(p1.equals(p2));
+           System.out.println(p2.equals(p3));
+           System.out.println(p1.equals(p3));
+           System.out.println(p3.equals(p4));
+           System.out.println(p1.equals("Gabe"));
+       }
    }
    ====
    import static org.junit.Assert.*;
@@ -333,7 +361,7 @@ Any class can override the inherited ``equals`` method by providing a method wit
          public void test1()
          {
              String output = getMethodOutput("main");
-             String expect = "false\nfalse\ntrue\ntrue";
+             String expect = "false\nfalse\ntrue\ntrue\nfalse";
 
              boolean passed = getResults(expect, output, "Checking output from main()", true);
              assertTrue(passed);
@@ -353,18 +381,26 @@ You can step through this code in the Java Visualizer by clicking on the followi
 To write your own equals method, you must:
 
 1. Use the ``public boolean equals(Object other)`` method signature
-2. Type cast other to your Classname
-3. Return whether this object's attribute(s) equals the other object's attribute(s) with == for primitive types like int and double, or equals for reference types like String or another class.
+
+2. Use ``instanceof`` to check if `other` is an instance of this class and return ``false`` if not.
+
+3. Type cast ``other`` to the current class
+
+4. Return whether this object's attribute(s) equals the other object's attribute(s) with ``==`` for primitive types like ``int`` and ``double``, or ``equals`` for reference types like ``String`` or another class.
 
 .. code-block:: java
 
     public boolean equals(Object other)
     {
+       if (!(other instanceof Classname))
+       {
+           return false;
+       }
        // Type cast other to your Classname
        Classname otherObj = (Classname) other;
        // Check if attributes are equal
        return (this.attribute == otherObj.attribute);
-       // or this.attribute.equals(otherObj.attribute) if attribute a String
+       // or this.attribute.equals(otherObj.attribute) if attribute is a reference type
     }
 
 If you need to check multiple attributes, for example a name and an address for Person objects, you can use && to combine tests.
@@ -373,6 +409,15 @@ If you need to check multiple attributes, for example a name and an address for 
 
     return (this.attribute1 == otherObj.attribute1) &&
            this.attribute2.equals(otherObj.attribute2)
+
+..
+  This is actually not really good advice. Overriding equals is unfortunately
+  quite complex in that there are a bunch of requirements on the contract. On of
+  which is that it be symmetric, i.e. o1.equals(o2) == o2.equals(o1). But if a
+  subclass overrides equals as described here it breaks symetry because
+  super.equals(sub) could return true while sub.equals(super) might return
+  false. Obviously we don't want to get into that whole mess but maybe it's
+  worth not leading them astray here.
 
 If you are writing an equals method for a subclass, you can call the superclass equals using the **super** keyword to check the attributes in the superclass and then check the attributes in the subclass.
 
@@ -389,20 +434,24 @@ In the following code, a bank account class contains the account holder's name a
 
 Work in pairs to write the following code and test each part before moving on to the next step:
 
-1. Write a subclass called SavingsAccount that extends Account and  adds an interest rate variable.
+1. Write a subclass called ``SavingsAccount`` that extends ``Account`` and  adds an interest rate variable.
 
-2. Write a constructor with 3 arguments (name, balance, interest rate) for the SavingsAccount class that uses the super constructor.
+2. Write a constructor with 3 arguments (name, balance, interest rate) for the ``SavingsAccount`` class that uses the super constructor.
 
-3. Write a toString() method for SavingsAccount that returns a call to the super toString() method and the interest rate.
+3. Write a ``toString`` method for ``SavingsAccount`` that returns a call to the super ``toString`` method and the interest rate.
 
-4. Write an equals method for SavingsAccount that calls the superclass equals method and checks that the interest rates are equal.
+4. Write an ``equals`` method for ``SavingsAccount`` that calls the `super class ``equals`` method and checks that the interest rates are equal.
 
 
 .. activecode:: challenge-9-7-savingsaccount
    :language: java
    :autograde: unittest
 
-   Complete the subclass SavingsAccount below which inherits from Account and adds an interest rate variable. Write a constructor with 3 arguments, a toString, and an equals method for it. Uncomment the code in main to test your new class and methods.
+   Complete the subclass ``SavingsAccount`` below which inherits from
+   ``Account`` and adds an interest rate variable. Write a constructor with 3
+   arguments, a ``toString``, and an ``equals`` method for it. Uncomment the
+   code in ``main`` to test your new class and methods.
+
    ~~~~
    public class Account
    {
@@ -540,14 +589,12 @@ Work in pairs to write the following code and test each part before moving on to
 Summary
 ---------
 
-- The Object class is the superclass of all other classes in Java and a part of the built-in java.lang package.
+- The ``Object`` class is the superclass of all other classes in Java and a part of the built-in ``java.lang`` package.
 
-- The following Object class methods and constructors, including what they do and when they are used, are part of the Java Quick Reference:
+- The following ``Object`` class methods are part of the Java Quick Reference:
 
-  - String toString()
-  - boolean equals(Object other)
+  - ``String toString()``
+  - ``boolean equals(Object other)``
 
 
 - Subclasses of Object often override the equals and toString methods with class-specific implementations.
-
-

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -46,7 +46,7 @@ The ``Object`` class is the superclass of all other classes in Java and a part
 of the built-in ``java.lang`` package. If a parent class isn't specified using
 the ``extends`` keyword, the class will inherit from the ``Object`` class. What
 does a class inherit from the ``Object`` class? The |AP CSA Reference Sheet|
-lists the two main methods that are most frequenly:
+lists the two main methods that are most frequently used:
 
 - ``String toString()``
 - ``boolean equals(Object other)``

--- a/_sources/Unit9-Inheritance/topic-9-7-Object.rst
+++ b/_sources/Unit9-Inheritance/topic-9-7-Object.rst
@@ -341,7 +341,7 @@ We want two ``Word`` objects to be considered ``equals`` if and only if they are
 spelled the same `and` come from the same languag. The latter requirement is
 because sometimes different languages have words that are spelled the same but
 with different meanings such as “pie” which in English is a tasty baked treat
-and in Spanish which is what we call a “foot” in English.
+and in Spanish is what we call a “foot” in English.
 
 |CodingEx| **Coding Exercise**
 


### PR DESCRIPTION
Mostly this was just adding some code styling backticks. However there is one issue that I left a comment about at line 413 which is some of the stuff in here about how to override `equals` is actually contrary to the requirements for overriding it described in Javadocs for `Object.equals`. Maybe that's okay and this falls under the category of acceptable white lies to tell students. But I'd rather find a way to avoid leading them astray on this.