### PR TITLE
Fix for main methods with throw clauses. And be more verbose if we can't find 'Caused by:'

### DIFF
--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -1110,6 +1110,10 @@ public class CodeTestHelper {
     private boolean checkParameters(Method m, Object[] arguments) {
         String header = m.toGenericString().replace(className + ".", "");
 
+        // ???: Is this still needed. As we discovered, it doesn't handle the
+        // case where the main method has a throws clause. I *think* that maybe
+        // with the other fix at line 321, this may not be needed anymore? I'm
+        // not sure. -Peter
         if (header.equals("public static void main(java.lang.String[])"))
             return true;
 

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -318,7 +318,7 @@ public class CodeTestHelper {
     public String getMethodOutput(String methodName)// throws IOException
     {
         if (methodName.equals("main")) {
-            return getMethodOutput(methodName, new String[1]);
+            return getMethodOutput(methodName, new Object[][] { new String[0] });
         }
         return getMethodOutput(methodName, null);
     }

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -988,39 +988,29 @@ public class CodeTestHelper {
 
     // https://stackoverflow.com/questions/10120709/difference-between-printstacktrace-and-tostring#:~:text=toString%20()%20gives%20name%20of,is%20raised%20in%20the%20application.&text=While%20e.,Jon%20wrote%20in%20his%20answer.
     private String stackToString(Throwable e) {
-        if (e == null)
+        if (e == null) {
             return "Exception: stack null";
+        }
 
         StringWriter sw = new StringWriter();
         e.printStackTrace(new PrintWriter(sw));
 
         String trace = sw.toString();
 
-        String returnString = "";
-
-        String location = "", except = "";
-
         String causedBy = "Caused by: ";
-        int expLen = causedBy.length();
         int expStart = trace.indexOf(causedBy);
 
-        returnString += "Start: " + expStart + "\n";
-
         if (expStart > -1) {
-            except = trace.substring(expStart + expLen);
-            // trace = trace.substring(0, expStart-1);
-
+            String except = trace.substring(expStart + causedBy.length());
             int expEnd = except.indexOf(className + ".java");
             expEnd = except.indexOf("\n", expEnd);
-
-            if (expEnd > -1)
+            if (expEnd > -1) {
                 except = except.substring(0, expEnd);
+            }
+            return except;
         } else {
-            return "Exception in method";
+            return "Exception in method:\n" + trace;
         }
-
-        return except;
-
     }
 
     /**


### PR DESCRIPTION
This started out as just a change to add the trace back into that otherwise cryptic error message we got today. I'm not sure, however, if it was intentional not to put all that stuff in student's faces. It might be ugly.

But the middle commit at least is important as it fixes the problem we were having. And the third commit is just a comment asking about whether we still need the special escape hatch for `main`.