### PR TITLE
Taking a crack at code digest idea.

### DIFF
--- a/CodeDigest.java
+++ b/CodeDigest.java
@@ -1,0 +1,21 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
+import java.util.stream.Collectors;
+
+public class CodeDigest {
+
+    public static void main(String[] args) throws NoSuchAlgorithmException, IOException {
+        String code = args[0].equals("-") ? getStdin() : Files.readString(Paths.get(args[0]));
+        System.out.println(CodeTestHelper.codeDigest(code));
+    }
+
+    private static String getStdin() throws IOException {
+        return new BufferedReader(new InputStreamReader(System.in))
+                .lines()
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -2,6 +2,7 @@ import java.io.*;
 import java.lang.reflect.*;
 
 import java.util.Arrays;
+import java.util.Formatter;
 
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -9,6 +10,9 @@ import java.util.regex.Matcher;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.charset.StandardCharsets;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import static org.junit.Assert.*;
 import org.junit.After;
@@ -34,7 +38,7 @@ import javax.tools.ToolProvider;
  * @author Kate McDonnell
  * @version 3.0.2
  * @since 2023-07-12
- * 
+ *
  * @update 3.0.2 - Kate fixed the bug that main method only running once created
  * @update 3.0.1 - Kate added code so main method only runs once
  * @update 2.0.2 - Peter Seibel updated to allow for "throws exception" in main
@@ -135,7 +139,7 @@ public class CodeTestHelper {
      * This method will return the final results of all tests so that they can be
      * printed to the screen. It then resets the final results so that the list does
      * not continually grow between different tests.
-     * 
+     *
      * @return String list of final results in proper format
      */
     public static String getFinalResults() {
@@ -154,7 +158,7 @@ public class CodeTestHelper {
      * This method generates the proper results for the test and then performs the
      * test by comparing the expected and actual strings. Non-string variables
      * should be made Strings before calling this method, using "" + num.
-     * 
+     *
      * @param expected This is the String with the output we expect to get from the
      *                 test
      * @param actual   This is the String with the actual output from the test
@@ -227,7 +231,7 @@ public class CodeTestHelper {
      * This method assumes that you know whether the test passes or fails, allowing
      * you to have expected and actual be different. This is helpful for testing a
      * condtion where expected and actual might not be the same.
-     * 
+     *
      * @param expected This is the String with the output we expect to get from the
      *                 test
      * @param actual   This is the String with the actual output from the test
@@ -246,7 +250,7 @@ public class CodeTestHelper {
      * This method generates the proper results for the test and then performs the
      * test by comparing the expected and actual double values, within a margin of
      * error of 0.005, so |expected - actual| < 0.005
-     * 
+     *
      * @param expected This is the double with the output we expect to get from the
      *                 test
      * @param actual   This is the double with the actual output from the test
@@ -262,7 +266,7 @@ public class CodeTestHelper {
      * This method generates the proper results for the test and then performs the
      * test by comparing the expected and actual double values, within a given
      * margin of error.
-     * 
+     *
      * @param expected This is the double with the output we expect to get from the
      *                 test
      * @param actual   This is the double with the actual output from the test
@@ -316,7 +320,7 @@ public class CodeTestHelper {
      * This method attempts to run a given method in a given class and returns the
      * output if it succeeds - only works for methods with String[] args parameter
      * at the moment ????
-     * 
+     *
      * @param String name of the class where the method is written
      * @param String name of the method
      * @return String output of method - whatever has been printed to the console or
@@ -335,7 +339,7 @@ public class CodeTestHelper {
      * specified arguments and returns the output if it succeeds - only works for
      * methods with String[] args parameter at the moment ???? - is designed to
      * return the output when any method has been called
-     * 
+     *
      * @param String name of the class where the method is written
      * @param String name of the method
      * @return String output of method - whatever has been printed to the console or
@@ -466,7 +470,7 @@ public class CodeTestHelper {
      * private String getString(String type, Method m, Object o, Object[] args) { if
      * (type.equals("int[]")) { int[] results = {};//(int[])m.invoke(o, args);
      * return Arrays.toString(results); }
-     * 
+     *
      * return ""+m.invoke(o, args); }
      */
     private String getInstanceMethodOutput(Method m, Object[] args)// throws IOException
@@ -511,7 +515,7 @@ public class CodeTestHelper {
      * This method prints the list of getter and setter methods in the class.
      * Awesome Tutorial for Getters and Setters -
      * http://tutorials.jenkov.com/java-reflection/getters-setters.html
-     * 
+     *
      * @param String name of the class where the methods are written
      * @return Nothing
      */
@@ -548,7 +552,7 @@ public class CodeTestHelper {
      * This method checks that the desired instance variables exist, based on name
      * and type. Awesome Tutorial -
      * http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
-     * 
+     *
      * @param String array of <<type name>> pairs, such as {"int num", "double avg"}
      * @return "pass" if they match, and an error message with information if they
      *         do not
@@ -595,7 +599,7 @@ public class CodeTestHelper {
      * This method counts how many private and public instance variables are
      * included in the class. Awesome Tutorial -
      * http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
-     * 
+     *
      * @param String name of the class
      * @return String the number of private and/or public instance variables
      */
@@ -631,7 +635,7 @@ public class CodeTestHelper {
      * This method checks that instance variables of the desired type exist, without
      * worrying about names. Awesome Tutorial -
      * http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
-     * 
+     *
      * @param String array of <<type>> values, such as {"int", "double"} in the
      *               desired order
      * @return "pass" if they match, and an error message with information if they
@@ -682,7 +686,7 @@ public class CodeTestHelper {
      * This method checks that the desired instance variables exist, based on name
      * and type. Awesome Tutorial -
      * http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
-     * 
+     *
      * @param String array of <<type name>> pairs, such as {"int num", "double avg"}
      * @return "pass" if they match, and an error message with information if they
      *         do not
@@ -1333,7 +1337,7 @@ public class CodeTestHelper {
         return code;
     }
 
-    public String removeComments(String code) {
+    public static String removeComments(String code) {
         int startBlock = code.indexOf("/*");
         int endBlock = -1;
         while (startBlock >= 0) {
@@ -1450,6 +1454,53 @@ public class CodeTestHelper {
         }
 
         return false;
+    }
+
+
+    /*
+     * Another way to detect changes in source code. Use the utility program
+     * CodeDigest to get the digest of the original code and then in the test
+     * use something like:
+     *
+     *  boolean passed = codeDigestChanged("1f92cb0f45abe66d191d9dcd05840c552a488109");
+     *
+     * This is at least more concise than including the original code as a
+     * string and gives us the chance to automate finding places where the
+     * original code no longer hashes to the hash we are looking for in unit
+     * test.
+     */
+    public boolean codeDigestChanged(String originalDigest) {
+        try {
+            String msg = "Checking that code has been changed";
+            String digest = codeDigest(getCode());
+            boolean passed = !digest.equals(originalDigest);
+            results += formatOutput("true", "" + passed, msg, passed);
+            results += "\n";
+            return passed;
+        } catch (NoSuchAlgorithmException nsae) {
+            String msg = "Test could not be completed";
+            results += formatOutput("true", "false", msg, false);;
+            results += "\n";
+            return false;
+        }
+    }
+
+    /*
+     * Compute the code digest: a SHA1 hash of a normalized string.
+     */
+    public static String codeDigest(String input) throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        String normalized = removeComments(input.replaceAll("\\s+", " ").trim());
+        byte[] bytes = normalized.getBytes(StandardCharsets.UTF_8);
+        return byteArrayToHexString(md.digest(bytes));
+    }
+
+    private static String byteArrayToHexString(byte[] bytes) {
+        Formatter formatter = new Formatter();
+        for (byte b : bytes) {
+            formatter.format("%02x", b);
+        }
+        return formatter.toString();
     }
 
     /*

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -1479,7 +1479,7 @@ public class CodeTestHelper {
             return passed;
         } catch (NoSuchAlgorithmException nsae) {
             String msg = "Test could not be completed";
-            results += formatOutput("true", "false", msg, false);;
+            results += formatOutput("true", "false", msg, false);
             results += "\n";
             return false;
         }


### PR DESCRIPTION
Here's an implementation of the idea I was thinking of. For me it's easier to copy the original code and run `pbpaste | java CodeDigest` and then stick the resulting hash into the unit test than to convert a bunch of code into a string. And there's the possibility I mentioned of being able to automatically detect places where the code and the hash has diverged.

What do you think?

(Sorry about some of the gratuitous white space changes—my editor is set up to trim trailing whitespace. Which in the long run minimizes diffs but in cases like this causes larger diffs.) 