### PR TITLE
Showing Main.java file for replits instead of black screen

### DIFF
--- a/_sources/Unit1-Getting-Started/topic-1-4-assignment.rst
+++ b/_sources/Unit1-Getting-Started/topic-1-4-assignment.rst
@@ -214,7 +214,7 @@ Variables are a powerful abstraction in programming because the same algorithm c
 
 .. raw:: html
 
-    <iframe height="500px" width="100%" style="max-width:90%; margin-left:5%"  src="https://firewalledreplit.com/@BerylHoffman/JavaIOExample?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="500px" width="100%" style="max-width:90%; margin-left:5%"  src="https://firewalledreplit.com/@BerylHoffman/JavaIOExample?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 Although you will not be tested in the AP CSA exam on using the Java input or the ``Scanner`` or ``Console`` classes, learning how to do input in Java is very useful and fun. For more information on using the ``Scanner`` class, go to https://www.w3schools.com/java/java_user_input.asp, and for the newer ``Console`` class, https://howtodoinjava.com/java-examples/console-input-output/.
 

--- a/_sources/Unit1-Getting-Started/topic-1-6-casting.rst
+++ b/_sources/Unit1-Getting-Started/topic-1-6-casting.rst
@@ -540,7 +540,7 @@ This would be a good project to work together in pairs, and switch drivers (who 
 
 .. |repl template| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Challenge1-6-Average-Template" target="_blank">repl template</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Challenge1-6-Average-Template#Main.java" target="_blank">repl template</a>
 
 Your teacher may suggest that you use a Java IDE like |repl| for this challenge so that you can use input to get these values using the |Scanner|. Here is a |repl template| that you can use to get started if you want to try the challenge with input.
 

--- a/_sources/Unit2-Using-Objects/JavaSwingGUIs.rst
+++ b/_sources/Unit2-Using-Objects/JavaSwingGUIs.rst
@@ -26,7 +26,7 @@
 
 .. |Java Swing Example| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/JavaSwingHello" target="_blank" style="text-decoration:underline">Java Swing Example</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/JavaSwingHello#Main.java" target="_blank" style="text-decoration:underline">Java Swing Example</a>
 
 .. |JButton Class| raw:: html
 
@@ -81,6 +81,6 @@ Here's a |Java Swing Example| on repl that sets up a ``JFrame`` with a ``JButton
 
 .. raw:: html
 
-    <iframe height="800px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/JavaSwingHello?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe><br>
+    <iframe height="800px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/JavaSwingHello?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe><br>
 
 To learn more about Java Swing, click on the different Swing components in the left navigation column of https://www.javatpoint.com/java-swing and try them out!

--- a/_sources/Unit2-Using-Objects/topic-2-1-objects-intro-turtles.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-1-objects-intro-turtles.rst
@@ -27,7 +27,7 @@
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank" style="text-decoration:underline">repl.it link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">repl.it link</a>
 
 .. |github| raw:: html
 

--- a/_sources/Unit2-Using-Objects/topic-2-2-constructors.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-2-constructors.rst
@@ -26,7 +26,7 @@
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank" style="text-decoration:underline">repl.it link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">repl.it link</a>
 
 .. |github| raw:: html
 

--- a/_sources/Unit2-Using-Objects/topic-2-3-methods-no-params.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-3-methods-no-params.rst
@@ -414,7 +414,7 @@ Here are some simple turtle methods that you can use:
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank">repl.it link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank">repl.it link</a>
 
 You may notice that it is challenging to have your turtle draw with these simple methods. In the next lesson, we will use more complex ``Turtle`` methods where you can indicate how many steps to take or what angle to turn that will make drawing a lot easier!
 

--- a/_sources/Unit2-Using-Objects/topic-2-4-methods-with-params.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-4-methods-with-params.rst
@@ -502,7 +502,7 @@ It may help to act out the code pretending you are the turtle. Remember that the
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank">repl.it link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank">repl.it link</a>
 
 
 .. activecode:: challenge2-4-TurtleHouse

--- a/_sources/Unit2-Using-Objects/topic-2-5-methods-return.rst
+++ b/_sources/Unit2-Using-Objects/topic-2-5-methods-return.rst
@@ -32,7 +32,7 @@
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle" target="_blank" style="text-decoration:underline">repl.it link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Turtle#Main.java" target="_blank" style="text-decoration:underline">repl.it link</a>
 
 .. |github| raw:: html
 

--- a/_sources/Unit3-If-Statements/magpie2.rst
+++ b/_sources/Unit3-If-Statements/magpie2.rst
@@ -212,7 +212,7 @@ When different methods are called from the main method, the control flows to the
 
 .. |Magpie lab on repl.it| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2" target="_blank">Magpie lab on repl.it</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2#Main.java" target="_blank">Magpie lab on repl.it</a>
 
 You can also run a version of the |Magpie lab on repl.it| that uses the Scanner class for input so that you can type in your own input to interact with it.
 

--- a/_sources/Unit3-If-Statements/magpie3.rst
+++ b/_sources/Unit3-If-Statements/magpie3.rst
@@ -175,7 +175,7 @@ Take a look at the ``findKeyword`` method below.  It has a ``while`` loop in it 
 
 .. |repl.it version 3| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v3" target="_blank">repl.it version 3</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v3#Main.java" target="_blank">repl.it version 3</a>
 
 Run the code below or this |repl.it version 3| to see this new method ``findKeyword`` in action. It is called from the ``getResponse`` method to print out an appropriate response based on a keyword. For example, looking for the word ``"no"`` to print out ``"Why so negative?"``, but it won't match no inside of another word like ``"another"``.
 

--- a/_sources/Unit3-If-Statements/magpie4.rst
+++ b/_sources/Unit3-If-Statements/magpie4.rst
@@ -322,7 +322,7 @@ Look at the code. See how it handles “I want to” and you/me statements.
 
 .. |repl.it version 4| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v4" target="_blank">repl.it version 4</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v4#Main.java" target="_blank">repl.it version 4</a>
 
 
 Then add two new methods, ``transformIWantStatement`` and ``transformIYouStatement``, and calls to each as described below. Alter the code either above in the active code window or on |repl.it version 4| or in an IDE of your choice:

--- a/_sources/Unit3-If-Statements/topic-3-2-ifs.rst
+++ b/_sources/Unit3-If-Statements/topic-3-2-ifs.rst
@@ -527,14 +527,14 @@ We encourage you to work in pairs for this challenge. Come up with 8 responses t
 
 .. |repl version| raw:: html
 
-    <a href="https://firewalledreplit.com/@BerylHoffman/Magic8BallTemplate" target="_blank" style="text-decoration:underline">repl version</a>
+    <a href="https://firewalledreplit.com/@BerylHoffman/Magic8BallTemplate#Main.java" target="_blank" style="text-decoration:underline">repl version</a>
 
 
 Here's a |repl version| that uses the Scanner class to first have the user ask a question. You can click on Open in Replit below, and click on Fork to make your own copy, and add your code in from above to try your code with user input.
 
 .. raw:: html
 
-    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Magic8BallTemplate?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Magic8BallTemplate?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 Summary
 -------------------

--- a/_sources/Unit3-If-Statements/topic-3-3-if-else.rst
+++ b/_sources/Unit3-If-Statements/topic-3-3-if-else.rst
@@ -474,7 +474,7 @@ The |Animal Guessing program| below uses the following decision tree:
 
 .. |Animal Guessing program| raw:: html
 
-    <a href="https://firewalledreplit.com/@BerylHoffman/GuessAnimal" target="_blank" style="text-decoration:underline">Animal Guessing program</a>
+    <a href="https://firewalledreplit.com/@BerylHoffman/GuessAnimal#Main.java" target="_blank" style="text-decoration:underline">Animal Guessing program</a>
 
 1. Try the |Animal Guessing program| below and run it a couple times thinking of an animal and answering the questions with y or n for yes or no. Did it guess your animal? Probably not! It's not very good. It can only guess 3 animals. Let's try to expand it!
 
@@ -501,7 +501,7 @@ The |Animal Guessing program| below uses the following decision tree:
 
 .. raw:: html
 
-    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/GuessAnimal?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/GuessAnimal?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 After you complete your code on repl.it, paste in your code below to run it through the auto-grader. Also include a link to your code on repl.it in comments.
 

--- a/_sources/Unit3-If-Statements/topic-3-4-else-ifs.rst
+++ b/_sources/Unit3-If-Statements/topic-3-4-else-ifs.rst
@@ -378,7 +378,7 @@ Here is a flowchart for a conditional with 3 options like in the code above.
 
 .. |repl link| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Adventure" target="_blank" style="text-decoration:underline">repl link</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Adventure#Main.java" target="_blank" style="text-decoration:underline">repl link</a>
 
 
 We encourage you to work in pairs for this challenge which is on repl.it (you will need an account there if you want to save your version).
@@ -398,7 +398,7 @@ In a game like Adventure, else if statements can be used to respond to commands 
 
 .. raw:: html
 
-    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Adventure?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="650px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Adventure?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 .. activecode:: challenge3-4-ElseIf-Adventure-autograde
   :language: java

--- a/_sources/Unit4-Iteration/topic-4-1-while-loops.rst
+++ b/_sources/Unit4-Iteration/topic-4-1-while-loops.rst
@@ -428,26 +428,26 @@ Input-Controlled Loops
 
 .. |Magpie chatbot lab on repl.it| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2" target="_blank">Magpie chatbot lab on repl.it</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2#Main.java" target="_blank">Magpie chatbot lab on repl.it</a>
 
 You can use a ``while`` loop to repeat the body of the loop a certain number of times as shown above.  However, a ``while`` loop is typically used when you don't know how many times the loop will execute. It is often used for a **input-controlled loop** where the user's input indicates when to stop. For example, in the |Magpie chatbot lab on repl.it| below, the while loop stops when you type in "Bye". The stopping value is often called the **sentinel value** for the loop. Notice that if you type in "Bye" right away, the loop will never run. If the loop condition evaluates to false initially, the loop body is not executed at all. Another way to stop the loop prematurely is to put in a ``return`` statement that makes it immediately return from the method.
 
 .. raw:: html
 
-    <iframe height="700px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe><p>
+    <iframe height="700px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Magpie-ChatBot-Lab-v2?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe><p>
 
 
 |CodingEx| **Coding Exercise**
 
 .. |numbers on repl.it| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Average" target="_blank">numbers on repl.it</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Average#Main.java" target="_blank">numbers on repl.it</a>
 
 Here's another example with |numbers on repl.it|. This code calculates the average of positive numbers, but it is missing the condition for the loop on line 14.  Let's use -1 as the **sentinel value**. Add the condition to  the while loop to run while the user does not input -1. What would happen if you forgot step 3 (change the loop variable - get a new input)? Try commenting out line 19 with // to see what happens (note there is a stop button at the top!).
 
 .. raw:: html
 
-    <iframe height="700px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Average?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="700px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Average?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 
 There are standard algorithms that use loops to compute the sum or average like above, or determine the minimum or maximum value entered, or the frequency of a certain condition. You can also use loops to identify if some integers are evenly divisible by other integers or identify the individual digits in an integer. We will see a lot more of these algorithms in Unit 6 with loops and arrays.
@@ -481,13 +481,13 @@ When you finish and run your program, what is a good guessing strategy for guess
 
 .. |repl.it| raw:: html
 
-   <a href="https://firewalledreplit.com/@BerylHoffman/Guessing-Game" target="_blank">repl.it</a>
+   <a href="https://firewalledreplit.com/@BerylHoffman/Guessing-Game#Main.java" target="_blank">repl.it</a>
 
 For this project, you will need to use the |Scanner class| for input and |repl.it| or another IDE of your choice.
 
 .. raw:: html
 
-    <iframe height="600px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Guessing-Game?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="600px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Guessing-Game?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
 
 
 .. activecode:: challenge4-1-loop-GuessingGame-autograde

--- a/_sources/Unit5-Writing-Classes/community-challenge.rst
+++ b/_sources/Unit5-Writing-Classes/community-challenge.rst
@@ -242,4 +242,4 @@ To learn more about Java Swing, click on the different Swing components in the l
 
 .. raw:: html
 
-    <iframe height="800px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Input-Form?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>
+    <iframe height="800px" width="100%" style="max-width:90%; margin-left:5%" src="https://firewalledreplit.com/@BerylHoffman/Java-Swing-Input-Form?lite=true#Main.java" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>


### PR DESCRIPTION
It seems adding #Main.java at the end of a replit link will make it show the file instead of a blank cover image. This used to be the default, but changed at some point. 