### PR TITLE
Backport renumbering script from BHSawesome

### DIFF
--- a/_sources/index.rst
+++ b/_sources/index.rst
@@ -29,10 +29,7 @@ To make sure the site saves your answers on questions, please click on the perso
 
 .. raw:: html
 
-    <ul><li><a class="reference internal" href="Unit1-Getting-Started/toctree.html">Unit 1 Getting Started and Primitive Types</a></li><li><a class="reference internal" href="Unit2-Using-Objects/toctree.html">Unit 2 Using Objects</a></li><li><a class="reference internal" href="Unit3-If-Statements/toctree.html">Unit 3 If Statements</a></li><li><a class="reference internal" href="Unit4-Iteration/toctree.html">Unit 4 Iteration/Loops</a></li><li><a class="reference internal" href="Unit5-Writing-Classes/toctree.html">Unit 5 Writing Classes</a></li><li><a class="reference internal" href="Unit6-Arrays/toctree.html">Unit 6 Arrays</a></li><li><a class="reference internal" href="Unit7-ArrayList/toctree.html">Unit 7 ArrayLists</a></li><li><a class="reference internal" href="Unit8-2DArray/toctree.html">Unit 8 2D Arrays</a></li><li><a class="reference internal" href="Unit9-Inheritance/toctree.html">Unit 9 Inheritance</a></li><li><a class="reference internal" href="Unit10-Recursion/toctree.html">Unit 10 Recursion</a></li><li>Practice units: <a class="reference internal" href="Unit11-posttest/toctree.html">11</a>, <a class="reference internal" href="Tests/toctree.html">12</a>, <a class="reference internal" href="TimedTests/toctree.html">13</a>, <a class="reference internal" href="MixedFreeResponse/toctree.html">14</a>, <a class="reference internal" href="FreeResponse/toctree.html">15</a></li><li><a class="reference internal" href="Stories/toctree.html">Stories</a></li></ul>
-
-
-
+    <ul id="small_toc"></ul>
 
 .. Here is where you specify the content and order of your new book.
 

--- a/_static/js/renumber.js
+++ b/_static/js/renumber.js
@@ -1,0 +1,101 @@
+// The new numbering for chapters in the book. The non-funny numbers should
+// basically correspond to the original units in CSAwesome which themselves
+// correspond to the order give by the College Board in the CED. For now the
+// funny numbers are commented out because I haven't added those chapters yet.
+
+const numbers = [
+  // add a unit 0 to the toctree and then uncomment the next line
+  // "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "11",
+  "12",
+  "13",
+  "14",
+  "15",
+  "16",
+  "17"
+];
+
+// Adjust these two values. They are indices, not the unit numbers.
+const practiceUnitsStart = 10;
+const practiceUnits = 5;
+const unitsAfterPractice = 1;
+
+// Derived
+const afterPractice = practiceUnitsStart + practiceUnits;
+const end = afterPractice + unitsAfterPractice;
+
+// Add selectors here if you find any more places where automatic numbers
+// appear. These selectors should select the elements that contain the text
+// starting with the unit number to be replaced.
+const selectors = [
+  '.toctree-wrapper ul li a',          // Main TOC
+  'span.section-number',               // Text in chapters
+  'li.dropdown.globaltoc-container a', // Dropdown menu
+];
+
+const chapterNum = /^(\d+)(\.| )(.*)$/;
+
+const newNumber = (orig) => numbers[orig - 1];
+
+const renumber = (e) => {
+  e.innerText = e.innerText.replace(chapterNum, (match, p1, p2, p3) => `${numbers[p1 - 1]}${p2}${p3}`);
+};
+
+
+const buildSmallTOC = () => {
+  const units = [...document.querySelectorAll('#table-of-contents .toctree-wrapper > ul > li')];
+
+  const smallTOC = document.createElement('ul');
+  const prep = units[0].cloneNode();
+  prep.append("Practice units: ");
+
+  const addToSmallTOC = (e) => {
+    const copy = e.cloneNode();
+    const a = e.querySelector('a').cloneNode(true);
+    a.innerText = a.innerText.replace(/^(.*?)\./, 'Unit $1:');
+    copy.append(a);
+    smallTOC.append(copy);
+  };
+
+  const addToPrepEntry = (e, i, arr) => {
+    const a = e.querySelector('a').cloneNode(true);
+    a.innerText = numbers[i + practiceUnitsStart];
+    prep.append(a);
+    if (i < arr.length - 1) prep.append(", ");
+  };
+
+  // Add the main units
+  units.slice(0, practiceUnitsStart).forEach(addToSmallTOC);
+
+  // The prep entry
+  units.slice(practiceUnitsStart, afterPractice).forEach(addToPrepEntry);
+  smallTOC.append(prep);
+
+  // And any remaining units.
+  units.slice(afterPractice, end).forEach(addToSmallTOC);
+
+  return smallTOC;
+};
+
+
+window.addEventListener("DOMContentLoaded", (event) => {
+
+  // Renumbering of the TOC and section headers.
+  selectors.forEach(s => {
+    document.querySelectorAll(s).forEach(renumber);
+  });
+
+  // Fill the small toc if it's on the page
+  document.getElementById('small_toc')?.replaceWith(buildSmallTOC());
+
+});

--- a/_static/js/renumber.js
+++ b/_static/js/renumber.js
@@ -3,6 +3,10 @@
 // correspond to the order give by the College Board in the CED. For now the
 // funny numbers are commented out because I haven't added those chapters yet.
 
+// Set this to true to skip renumbering things if they won't actually change.
+// You'll still get the small table of contents built from the actual TOC.
+const skipRenumbering = true;
+
 const numbers = [
   // add a unit 0 to the toctree and then uncomment the next line
   // "0",
@@ -90,10 +94,12 @@ const buildSmallTOC = () => {
 
 window.addEventListener("DOMContentLoaded", (event) => {
 
-  // Renumbering of the TOC and section headers.
-  selectors.forEach(s => {
-    document.querySelectorAll(s).forEach(renumber);
-  });
+  if (!skipRenumbering) {
+    // Renumbering of the TOC and section headers.
+    selectors.forEach(s => {
+      document.querySelectorAll(s).forEach(renumber);
+    });
+  }
 
   // Fill the small toc if it's on the page
   document.getElementById('small_toc')?.replaceWith(buildSmallTOC());

--- a/conf.py
+++ b/conf.py
@@ -251,5 +251,6 @@ htmlhelp_basename = 'PythonCoursewareProjectdoc'
 
 # custom  files in _static
 setup.custom_css_files = ['css/custom.css',]
+setup.custom_js_files = ['js/renumber.js',]
 
 # setup function moved to runestone 5.8.0 release


### PR DESCRIPTION
As it stands this doesn't really change anything. But if you want a unit 0 you can easily have it: just add a new unit into the toctree before the current Unit 1 and then uncomment the `"0"` in `_static/js/renumber.js`.

Oh, you might also have to adjust the value of `practiceUnitsStart` to 11 to get the small TOC to be regenerated. (I replaced the static small TOC with one built by Javascript so it would keep in sync with the renumbered units automatically.)