### PR TITLE
New style of assertions in CodeTestHelper.

### DIFF
--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -3,6 +3,7 @@ import java.lang.reflect.*;
 
 import java.util.Arrays;
 import java.util.Formatter;
+import java.util.Objects;
 
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -14,7 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -242,8 +243,6 @@ public class CodeTestHelper {
     public boolean getResults(String expected, String actual, String msg, boolean pass) {
         String output = formatOutput(expected, actual, msg, pass);
         results += output + "\n";
-        // System.out.println(output);
-
         return pass;
     }
 
@@ -286,6 +285,40 @@ public class CodeTestHelper {
 
         return passed;
     }
+
+
+    // New style assertions. Because JUnit doesn't report any information when
+    // tests pass we need to always append to results and then call JUnit's
+    // assertTrue method because the Runestone test runner *does* use the count
+    // of passes and attempts that is recorded by JUnit based on calls to
+    // assertions methods. Thus if you call any other JUnit assertions it will
+    // mess up the count that Runestone prints under the table of results.
+
+    public void expect(String expected, String got, String label) {
+        recordResult(expected, got, label, Objects.equals(expected, got));
+    }
+
+    public void expectExact(double expected, double got, String label) {
+        recordResult(String.valueOf(expected), String.valueOf(got), label, expected == got);
+    }
+
+    public void expect(double expected, double got, String label) {
+        recordResult(String.valueOf(expected), String.valueOf(got), label, Math.abs(expected - got) < 0.005);
+    }
+
+    public void expect(int expected, int got, String label) {
+        recordResult(String.valueOf(expected), String.valueOf(got), label, expected == got);
+    }
+
+    public void expect(boolean expected, boolean got, String label) {
+        recordResult(String.valueOf(expected), String.valueOf(got), label, expected == got);
+    }
+
+    private void recordResult(String expected, String got, String label, boolean passed) {
+        results += formatOutput(String.valueOf(expected), String.valueOf(got), label, passed) + "\n";
+        assertTrue(passed);
+    }
+
 
     private String formatOutput(String expected, String actual, String msg, boolean passed) {
         String output = "";

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -315,7 +315,7 @@ public class CodeTestHelper {
     }
 
     private void recordResult(String expected, String got, String label, boolean passed) {
-        results += formatOutput(String.valueOf(expected), String.valueOf(got), label, passed) + "\n";
+        results += formatOutput(expected, got, label, passed) + "\n";
         assertTrue(passed);
     }
 

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -40,6 +40,7 @@ import javax.tools.ToolProvider;
  * @version 3.0.2
  * @since 2023-07-12
  *
+ * @update 3.1.0 - Peter added a new set of `expect` methods.
  * @update 3.0.3 - Peter added a codeDigestChanged method.
  * @update 3.0.2 - Kate fixed the bug that main method only running once created
  * @update 3.0.1 - Kate added code so main method only runs once


### PR DESCRIPTION
I think I got to the bottom of my confusion about CodeTestHelper. As I explain in the comment in this PR, the way CodeTestHelper and Runestone work together to display test results basically means that every time we make a JUnit assertion we need to also append a correctly formatted result to the `results` variable in CodeTestHelper. This PR adds several new `expect` methods that are much simpler that the various `getResults` and basically just do reasonable equality (or thereabouts) comparisons of expected and actual values and stores the result and makes the assertion.

It makes it possible to write tests like this:

```java
   public class Doubler
   {

       // TODO: Add definition of doubled here

       public static void main(String[] argv)
       {
           System.out.println("Twice 2 is: " + doubled(2));
           doubled(4); // Notice that this has no effect when you run the program.
       }
   }
   ====
   import org.junit.Test;

   public class RunestoneTests extends CodeTestHelper {

       private void check(int n) {
         expect(n * 2, Doubler.doubled(n), "doubled(" + n + ")");
       }

       @Test
       public void testDoubledPositiveNumber() {
         check(10);
       }

       @Test
       public void testDoubledNegativeNumber() {
         check(-5);
       }

       @Test
       public void testDoubledZero() {
         check(0);
       }

       @Test
       public void testDoubledLargeNumber() {
         check(Integer.MAX_VALUE / 2);
       }
   }
```