### PR TITLE
pass args instead of null

### DIFF
--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -439,7 +439,9 @@ public class CodeTestHelper {
                 if (m.getName().equals(methodName)) {
 
                     if (!checkStaticMethod(m) && checkReturnType(m, "void")) {
-                        return getInstanceMethodOutput(m, null);
+                        // this was ignoring the args passed in before
+                        // which is probably not the desired behavior
+                        return getInstanceMethodOutput(m, args);
                     } else if (!checkStaticMethod(m)) {
                         Object o = getTestInstance();
 

--- a/CodeTestHelper.java
+++ b/CodeTestHelper.java
@@ -439,8 +439,6 @@ public class CodeTestHelper {
                 if (m.getName().equals(methodName)) {
 
                     if (!checkStaticMethod(m) && checkReturnType(m, "void")) {
-                        // this was ignoring the args passed in before
-                        // which is probably not the desired behavior
                         return getInstanceMethodOutput(m, args);
                     } else if (!checkStaticMethod(m)) {
                         Object o = getTestInstance();


### PR DESCRIPTION
If you want to get the output from a non-static method that takes arguments, the tester will currently try to call the method with no arguments which will put an exception in the output instead of the output of the method.

This small change should fix that.
